### PR TITLE
fix: P0/P1 SSR double-end, Electron-safe router, store tearing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -506,7 +505,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -555,7 +553,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2583,7 +2580,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2661,7 +2659,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2672,7 +2669,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2683,7 +2679,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2914,6 +2909,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2924,6 +2920,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2994,7 +2991,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3227,7 +3223,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -3514,7 +3511,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -3592,6 +3588,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3819,7 +3816,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3862,6 +3858,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3886,7 +3883,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3896,7 +3892,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3909,7 +3904,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4384,7 +4380,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/__tests__/router.test.tsx
+++ b/src/__tests__/router.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ChenAdaptiveRouter, ChenHashRouter } from '../router/index';
+
+// ─── ChenHashRouter re-export ─────────────────────────────────────────────────
+
+describe('ChenHashRouter', () => {
+  it('renders without crashing', () => {
+    const { container } = render(
+      React.createElement(ChenHashRouter, null,
+        React.createElement('div', null, 'hash route')
+      )
+    );
+    expect(container.textContent).toContain('hash route');
+  });
+});
+
+// ─── ChenAdaptiveRouter ───────────────────────────────────────────────────────
+
+describe('ChenAdaptiveRouter', () => {
+  let originalProtocol: string;
+
+  beforeEach(() => {
+    // Store original location descriptor
+    originalProtocol = window.location.protocol;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // Restore window.location.protocol if it was changed
+  });
+
+  it('mode="browser" renders BrowserRouter content regardless of protocol', () => {
+    // Simulate file: protocol but force browser mode
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, protocol: 'file:' },
+      writable: true,
+      configurable: true,
+    });
+
+    const { container } = render(
+      React.createElement(
+        ChenAdaptiveRouter,
+        { mode: 'browser' },
+        React.createElement('div', null, 'browser-content')
+      )
+    );
+    expect(container.textContent).toContain('browser-content');
+  });
+
+  it('mode="hash" renders HashRouter content regardless of protocol', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, protocol: 'http:' },
+      writable: true,
+      configurable: true,
+    });
+
+    const { container } = render(
+      React.createElement(
+        ChenAdaptiveRouter,
+        { mode: 'hash' },
+        React.createElement('div', null, 'hash-content')
+      )
+    );
+    expect(container.textContent).toContain('hash-content');
+  });
+
+  it('mode="auto" with http: protocol uses BrowserRouter', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, protocol: 'http:' },
+      writable: true,
+      configurable: true,
+    });
+
+    const { container } = render(
+      React.createElement(
+        ChenAdaptiveRouter,
+        { mode: 'auto' },
+        React.createElement('div', null, 'auto-http-content')
+      )
+    );
+    expect(container.textContent).toContain('auto-http-content');
+  });
+
+  it('mode="auto" with file: protocol uses HashRouter', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, protocol: 'file:' },
+      writable: true,
+      configurable: true,
+    });
+
+    const { container } = render(
+      React.createElement(
+        ChenAdaptiveRouter,
+        { mode: 'auto' },
+        React.createElement('div', null, 'auto-file-content')
+      )
+    );
+    expect(container.textContent).toContain('auto-file-content');
+  });
+
+  it('default mode (auto) with https: protocol uses BrowserRouter', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, protocol: 'https:' },
+      writable: true,
+      configurable: true,
+    });
+
+    const { container } = render(
+      React.createElement(
+        ChenAdaptiveRouter,
+        {},
+        React.createElement('div', null, 'default-https')
+      )
+    );
+    expect(container.textContent).toContain('default-https');
+  });
+
+  it('resolves to hash when mode is "hash" even on http: protocol', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, protocol: 'http:' },
+      writable: true,
+      configurable: true,
+    });
+
+    // mode='hash' should always use HashRouter
+    // HashRouter uses window.location.hash, BrowserRouter uses window.history
+    // We verify it renders correctly — both work, but hash mode uses #-based routing
+    const { container } = render(
+      React.createElement(
+        ChenAdaptiveRouter,
+        { mode: 'hash' },
+        React.createElement('span', null, 'forced-hash')
+      )
+    );
+    expect(container.textContent).toContain('forced-hash');
+  });
+
+  it('mode resolution: "browser" maps to browser regardless', () => {
+    // Covers the mode === 'browser' branch in the ternary
+    const { container } = render(
+      React.createElement(
+        ChenAdaptiveRouter,
+        { mode: 'browser' },
+        React.createElement('p', null, 'explicit-browser')
+      )
+    );
+    expect(container.textContent).toContain('explicit-browser');
+  });
+
+  it('passes extra props (e.g. basename) down to underlying router', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, protocol: 'http:' },
+      writable: true,
+      configurable: true,
+    });
+
+    // Should not throw when passing a basename prop
+    expect(() =>
+      render(
+        React.createElement(
+          ChenAdaptiveRouter,
+          { mode: 'browser', basename: '/' },
+          React.createElement('div', null, 'with-basename')
+        )
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/__tests__/ssr.test.ts
+++ b/src/__tests__/ssr.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { PassThrough, Writable } from 'stream';
+import { renderToStream } from '../ssr/index';
+import type { RenderToStreamOptions } from '../ssr/index';
+
+// Helper: collect all chunks written to a Writable into a string.
+function collectWritable(): { writable: Writable; getOutput: () => string } {
+  const chunks: Buffer[] = [];
+  const writable = new PassThrough();
+  writable.on('data', (chunk: Buffer) => chunks.push(chunk));
+  return {
+    writable,
+    getOutput: () => Buffer.concat(chunks).toString('utf8'),
+  };
+}
+
+// Helper: wait for the writable's 'finish' event (i.e., writable.end() was called)
+function waitForFinish(writable: Writable): Promise<void> {
+  return new Promise((resolve, reject) => {
+    writable.on('finish', resolve);
+    writable.on('error', reject);
+  });
+}
+
+const baseOptions: RenderToStreamOptions = {
+  clientEntry: '/client.js',
+  title: 'Test',
+  lang: 'en',
+  rootId: 'root',
+};
+
+// ─── renderToStream — PassThrough bridge (refactored in PR) ──────────────────
+
+describe('renderToStream', () => {
+  it('writes beforeContent (HTML opening) followed by afterContent (HTML closing)', async () => {
+    const { writable, getOutput } = collectWritable();
+    const element = React.createElement('div', null, 'Hello SSR');
+
+    renderToStream(element, writable, baseOptions);
+    await waitForFinish(writable);
+
+    const output = getOutput();
+    expect(output).toContain('<!DOCTYPE html>');
+    expect(output).toContain('<html lang="en">');
+    expect(output).toContain('<div id="root">');
+    expect(output).toContain('Hello SSR');
+    expect(output).toContain('</div>');
+    expect(output).toContain('<script type="module" src="/client.js">');
+    expect(output).toContain('</html>');
+  });
+
+  it('afterContent appears after React-rendered content (correct ordering)', async () => {
+    const { writable, getOutput } = collectWritable();
+    const element = React.createElement('span', null, 'ordered-content');
+
+    renderToStream(element, writable, baseOptions);
+    await waitForFinish(writable);
+
+    const output = getOutput();
+    const reactContentIdx = output.indexOf('ordered-content');
+    const closingIdx = output.indexOf('</div>');
+    const scriptIdx = output.indexOf('<script');
+    const closingHtmlIdx = output.indexOf('</html>');
+
+    expect(reactContentIdx).toBeGreaterThan(-1);
+    expect(closingIdx).toBeGreaterThan(reactContentIdx);
+    expect(scriptIdx).toBeGreaterThan(closingIdx);
+    expect(closingHtmlIdx).toBeGreaterThan(scriptIdx);
+  });
+
+  it('calls onShellReady callback', async () => {
+    const { writable } = collectWritable();
+    const onShellReady = vi.fn();
+
+    renderToStream(React.createElement('div'), writable, {
+      ...baseOptions,
+      onShellReady,
+    });
+    await waitForFinish(writable);
+
+    expect(onShellReady).toHaveBeenCalledOnce();
+  });
+
+  it('calls onAllReady callback after stream finishes', async () => {
+    const { writable } = collectWritable();
+    const onAllReady = vi.fn();
+
+    renderToStream(React.createElement('div'), writable, {
+      ...baseOptions,
+      onAllReady,
+    });
+    await waitForFinish(writable);
+
+    expect(onAllReady).toHaveBeenCalledOnce();
+  });
+
+  it('exposes __chenAbort on the writable', () => {
+    const { writable } = collectWritable();
+
+    renderToStream(React.createElement('div'), writable, baseOptions);
+
+    expect(typeof (writable as Writable & { __chenAbort?: () => void }).__chenAbort).toBe('function');
+  });
+
+  it('includes the title tag in the HTML shell when provided', async () => {
+    const { writable, getOutput } = collectWritable();
+
+    renderToStream(React.createElement('div'), writable, {
+      ...baseOptions,
+      title: 'My App',
+    });
+    await waitForFinish(writable);
+
+    expect(getOutput()).toContain('<title>My App</title>');
+  });
+
+  it('includes cssHref link tag when provided', async () => {
+    const { writable, getOutput } = collectWritable();
+
+    renderToStream(React.createElement('div'), writable, {
+      ...baseOptions,
+      cssHref: '/style.css',
+    });
+    await waitForFinish(writable);
+
+    expect(getOutput()).toContain('<link rel="stylesheet" href="/style.css">');
+  });
+
+  it('includes headTags in the HTML shell', async () => {
+    const { writable, getOutput } = collectWritable();
+
+    renderToStream(React.createElement('div'), writable, {
+      ...baseOptions,
+      headTags: ['<meta name="description" content="test">'],
+    });
+    await waitForFinish(writable);
+
+    expect(getOutput()).toContain('<meta name="description" content="test">');
+  });
+
+  it('uses custom rootId in the HTML shell', async () => {
+    const { writable, getOutput } = collectWritable();
+
+    renderToStream(React.createElement('div'), writable, {
+      ...baseOptions,
+      rootId: 'app',
+    });
+    await waitForFinish(writable);
+
+    expect(getOutput()).toContain('<div id="app">');
+  });
+
+  it('does not write afterContent if writable is already destroyed before bridge ends', async () => {
+    // This tests the guard: if (writable.destroyed || writable.writableEnded) return;
+    const onAllReady = vi.fn();
+    const onError = vi.fn();
+
+    // Create a writable that we'll destroy immediately after shell
+    const chunks: string[] = [];
+    const writable = new PassThrough();
+    writable.on('data', (d: Buffer) => chunks.push(d.toString()));
+
+    const onShellReady = vi.fn(() => {
+      // Destroy the writable right after shell is ready
+      writable.destroy(new Error('client disconnected'));
+    });
+
+    await new Promise<void>((resolve) => {
+      writable.on('close', resolve);
+      writable.on('error', () => resolve()); // swallow the error for test
+
+      renderToStream(React.createElement('div', null, 'content'), writable, {
+        ...baseOptions,
+        onShellReady,
+        onAllReady,
+        onError,
+      });
+    });
+
+    // onAllReady should NOT have been called because writable was destroyed
+    expect(onAllReady).not.toHaveBeenCalled();
+  });
+
+  it('calls onError callback when bridge encounters an error', async () => {
+    const onError = vi.fn();
+
+    const chunks: Buffer[] = [];
+    const writable = new PassThrough();
+    writable.on('data', (d: Buffer) => chunks.push(d));
+
+    // We'll manually emit an error on the writable to test bi-directional error propagation
+    let resolved = false;
+    const done = new Promise<void>((resolve) => {
+      writable.on('close', () => {
+        if (!resolved) { resolved = true; resolve(); }
+      });
+      writable.on('error', () => {
+        if (!resolved) { resolved = true; resolve(); }
+      });
+    });
+
+    renderToStream(React.createElement('div'), writable, {
+      ...baseOptions,
+      onError,
+    });
+
+    // Emit an error on writable to trigger the error propagation path
+    process.nextTick(() => {
+      if (!writable.destroyed && !writable.writableEnded) {
+        writable.destroy(new Error('upstream error'));
+      }
+    });
+
+    await done;
+    // onError may or may not be called depending on timing, but writable should be destroyed
+    expect(writable.destroyed).toBe(true);
+  });
+
+  it('writable ends exactly once (no double-end from bridge)', async () => {
+    const { writable, getOutput } = collectWritable();
+    let endCount = 0;
+    const origEnd = writable.end.bind(writable);
+    writable.end = (...args: Parameters<typeof writable.end>) => {
+      endCount++;
+      return origEnd(...args);
+    };
+
+    renderToStream(React.createElement('div', null, 'end-once'), writable, baseOptions);
+    await waitForFinish(writable);
+
+    expect(endCount).toBe(1);
+    expect(getOutput()).toContain('end-once');
+  });
+
+  it('renders nested React elements correctly', async () => {
+    const { writable, getOutput } = collectWritable();
+    const element = React.createElement(
+      'section',
+      null,
+      React.createElement('h1', null, 'Title'),
+      React.createElement('p', null, 'Paragraph')
+    );
+
+    renderToStream(element, writable, baseOptions);
+    await waitForFinish(writable);
+
+    const output = getOutput();
+    expect(output).toContain('<h1>');
+    expect(output).toContain('Title');
+    expect(output).toContain('<p>');
+    expect(output).toContain('Paragraph');
+  });
+});

--- a/src/__tests__/use-store.test.tsx
+++ b/src/__tests__/use-store.test.tsx
@@ -204,21 +204,20 @@ describe('createStore', () => {
     const { result } = renderHook(
       () => {
         renderCount++;
-        return objStore.useStoreSelector((s) => s.nested, shallowEqual);
+        return {
+          nested: objStore.useStoreSelector((s) => s.nested, shallowEqual),
+          dispatch: objStore.useStoreDispatch(),
+        };
       },
       { wrapper: objWrapper }
     );
 
     const initialRenders = renderCount;
-    // Dispatch a change that changes 'other' but creates a new 'nested' reference with same value
-    act(() => objStore.useStoreDispatch && result.current);
-    // Update only 'other', nested.x stays the same
-    const dispatch = renderHook(() => objStore.useStoreDispatch(), { wrapper: objWrapper });
-    act(() => dispatch.result.current({ nested: { x: 1 }, other: 99 }));
+    // Update only 'other'，nested.x 保持不变；新建一个 nested 引用以验证 equalityFn 生效
+    act(() => result.current.dispatch({ nested: { x: 1 }, other: 99 }));
 
-    // The selector returns nested object; equalityFn says x is same → no extra render
-    expect(result.current.x).toBe(1);
-    // renderCount should not have increased due to the state change (selector equal)
+    // selector 返回 nested 对象；equalityFn 认为 x 相同 → 不应触发额外渲染
+    expect(result.current.nested.x).toBe(1);
     expect(renderCount).toBe(initialRenders);
   });
 
@@ -230,15 +229,17 @@ describe('createStore', () => {
     const objWrapper2 = ({ children }: { children: React.ReactNode }) =>
       React.createElement(objStore2.StoreProvider, null, children);
 
-    const dispatchHook = renderHook(() => objStore2.useStoreDispatch(), { wrapper: objWrapper2 });
     const { result } = renderHook(
-      () => objStore2.useStoreSelector((s) => s.items),
+      () => ({
+        items: objStore2.useStoreSelector((s) => s.items),
+        dispatch: objStore2.useStoreDispatch(),
+      }),
       { wrapper: objWrapper2 }
     );
 
     const newItems = [4, 5, 6];
-    act(() => dispatchHook.result.current({ items: newItems }));
-    expect(result.current).toBe(newItems);
+    act(() => result.current.dispatch({ items: newItems }));
+    expect(result.current.items).toBe(newItems);
   });
 
   it('多个 StoreProvider 实例各有独立状态', () => {
@@ -248,9 +249,9 @@ describe('createStore', () => {
     });
 
     const wrapperA = ({ children }: { children: React.ReactNode }) =>
-      React.createElement(sharedDef.StoreProvider, { initialState: { value: 10 } }, children);
+      React.createElement(sharedDef.StoreProvider, { initialState: { value: 10 }, children });
     const wrapperB = ({ children }: { children: React.ReactNode }) =>
-      React.createElement(sharedDef.StoreProvider, { initialState: { value: 20 } }, children);
+      React.createElement(sharedDef.StoreProvider, { initialState: { value: 20 }, children });
 
     const { result: resultA } = renderHook(() => sharedDef.useStore(), { wrapper: wrapperA });
     const { result: resultB } = renderHook(() => sharedDef.useStore(), { wrapper: wrapperB });

--- a/src/__tests__/use-store.test.tsx
+++ b/src/__tests__/use-store.test.tsx
@@ -183,4 +183,205 @@ describe('createStore', () => {
       renderHook(() => counterStore.useStoreDispatch());
     }).toThrow();
   });
+
+  it('在 Provider 外使用 useStoreSelector 应抛出错误', () => {
+    expect(() => {
+      renderHook(() => counterStore.useStoreSelector((s) => s.count));
+    }).toThrow();
+  });
+
+  it('useStoreSelector 自定义 equalityFn：浅比较对象时不触发多余渲染', () => {
+    const objStore = createStore<{ nested: { x: number }; other: number }>({
+      name: 'obj-store',
+      initialState: { nested: { x: 1 }, other: 0 },
+    });
+    const objWrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(objStore.StoreProvider, null, children);
+
+    let renderCount = 0;
+    const shallowEqual = (a: { x: number }, b: { x: number }) => a.x === b.x;
+
+    const { result } = renderHook(
+      () => {
+        renderCount++;
+        return objStore.useStoreSelector((s) => s.nested, shallowEqual);
+      },
+      { wrapper: objWrapper }
+    );
+
+    const initialRenders = renderCount;
+    // Dispatch a change that changes 'other' but creates a new 'nested' reference with same value
+    act(() => objStore.useStoreDispatch && result.current);
+    // Update only 'other', nested.x stays the same
+    const dispatch = renderHook(() => objStore.useStoreDispatch(), { wrapper: objWrapper });
+    act(() => dispatch.result.current({ nested: { x: 1 }, other: 99 }));
+
+    // The selector returns nested object; equalityFn says x is same → no extra render
+    expect(result.current.x).toBe(1);
+    // renderCount should not have increased due to the state change (selector equal)
+    expect(renderCount).toBe(initialRenders);
+  });
+
+  it('useStoreSelector 默认 Object.is 比较：引用不同时触发重新渲染', () => {
+    const objStore2 = createStore<{ items: number[] }>({
+      name: 'items-store',
+      initialState: { items: [1, 2, 3] },
+    });
+    const objWrapper2 = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(objStore2.StoreProvider, null, children);
+
+    const dispatchHook = renderHook(() => objStore2.useStoreDispatch(), { wrapper: objWrapper2 });
+    const { result } = renderHook(
+      () => objStore2.useStoreSelector((s) => s.items),
+      { wrapper: objWrapper2 }
+    );
+
+    const newItems = [4, 5, 6];
+    act(() => dispatchHook.result.current({ items: newItems }));
+    expect(result.current).toBe(newItems);
+  });
+
+  it('多个 StoreProvider 实例各有独立状态', () => {
+    const sharedDef = createStore<{ value: number }>({
+      name: 'multi-provider',
+      initialState: { value: 0 },
+    });
+
+    const wrapperA = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(sharedDef.StoreProvider, { initialState: { value: 10 } }, children);
+    const wrapperB = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(sharedDef.StoreProvider, { initialState: { value: 20 } }, children);
+
+    const { result: resultA } = renderHook(() => sharedDef.useStore(), { wrapper: wrapperA });
+    const { result: resultB } = renderHook(() => sharedDef.useStore(), { wrapper: wrapperB });
+
+    expect(resultA.current.value).toBe(10);
+    expect(resultB.current.value).toBe(20);
+  });
+});
+
+// ─── createSimpleStore (new selector overloads) ──────────────────────────────
+
+describe('createSimpleStore — selector overloads (new in PR)', () => {
+  it('useStore with selector 返回选取的字段', () => {
+    const store = createSimpleStore({ count: 5, name: 'test' });
+    const { result } = renderHook(() => store.useStore((s) => s.count));
+    expect(result.current).toBe(5);
+  });
+
+  it('useStore with selector 在对应字段更新时重新渲染', () => {
+    const store = createSimpleStore({ count: 0, name: 'test' });
+    const { result } = renderHook(() => store.useStore((s) => s.count));
+
+    act(() => store.setState({ count: 42 }));
+    expect(result.current).toBe(42);
+  });
+
+  it('useStore with selector + custom equalityFn 避免不必要重渲染', () => {
+    const store = createSimpleStore({ nested: { x: 1 }, other: 0 });
+    let renderCount = 0;
+    const shallowEqual = (a: { x: number }, b: { x: number }) => a.x === b.x;
+
+    const { result } = renderHook(() => {
+      renderCount++;
+      return store.useStore((s) => s.nested, shallowEqual);
+    });
+
+    const initialRenders = renderCount;
+    // Update other, nested.x stays same value (new reference)
+    act(() => store.setState({ nested: { x: 1 }, other: 99 }));
+
+    expect(result.current.x).toBe(1);
+    expect(renderCount).toBe(initialRenders);
+  });
+
+  it('useStore without selector 返回完整 state', () => {
+    const store = createSimpleStore({ a: 1, b: 2 });
+    const { result } = renderHook(() => store.useStore());
+    expect(result.current).toEqual({ a: 1, b: 2 });
+  });
+
+  it('useDispatch 返回稳定的 setState 引用', () => {
+    const store = createSimpleStore({ count: 0 });
+    const { result, rerender } = renderHook(() => store.useDispatch());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});
+
+// ─── useGlobalStore — selector overloads (new in PR) ─────────────────────────
+
+describe('useGlobalStore — selector overloads (new in PR)', () => {
+  it('useGlobalStore with selector 返回选取的值', () => {
+    const store = createSimpleStore({ count: 7, label: 'hello' });
+    const { result } = renderHook(() => useGlobalStore(store, (s) => s.count));
+    expect(result.current).toBe(7);
+  });
+
+  it('useGlobalStore with selector 在字段更新时重新渲染', () => {
+    const store = createSimpleStore({ count: 0 });
+    const { result } = renderHook(() => useGlobalStore(store, (s) => s.count));
+
+    act(() => store.setState({ count: 100 }));
+    expect(result.current).toBe(100);
+  });
+
+  it('useGlobalStore with selector + custom equalityFn 避免不必要重渲染', () => {
+    const store = createSimpleStore({ nested: { x: 1 }, other: 0 });
+    let renderCount = 0;
+    const shallowEqual = (a: { x: number }, b: { x: number }) => a.x === b.x;
+
+    const { result } = renderHook(() => {
+      renderCount++;
+      return useGlobalStore(store, (s) => s.nested, shallowEqual);
+    });
+
+    const initialRenders = renderCount;
+    act(() => store.setState({ nested: { x: 1 }, other: 55 }));
+
+    expect(result.current.x).toBe(1);
+    expect(renderCount).toBe(initialRenders);
+  });
+
+  it('useGlobalStore without selector 返回完整 state', () => {
+    const store = createSimpleStore({ x: 10, y: 20 });
+    const { result } = renderHook(() => useGlobalStore(store));
+    expect(result.current).toEqual({ x: 10, y: 20 });
+  });
+
+  it('useGlobalStore selector 值变化时触发重新渲染', () => {
+    const store = createSimpleStore({ count: 0, name: 'a' });
+    const { result } = renderHook(() => useGlobalStore(store, (s) => s.name));
+
+    act(() => store.setState({ name: 'b' }));
+    expect(result.current).toBe('b');
+  });
+});
+
+// ─── useGlobalStoreDispatch (simplified to direct store.setState) ─────────────
+
+describe('useGlobalStoreDispatch — simplified return (new in PR)', () => {
+  it('返回的函数与 store.setState 是同一引用', () => {
+    const store = createSimpleStore({ count: 0 });
+    const { result } = renderHook(() => useGlobalStoreDispatch(store));
+    expect(result.current).toBe(store.setState);
+  });
+
+  it('调用后正确更新 store 状态', () => {
+    const store = createSimpleStore({ count: 0 });
+    const { result: dispatchResult } = renderHook(() => useGlobalStoreDispatch(store));
+    const { result: storeResult } = renderHook(() => useGlobalStore(store));
+
+    act(() => dispatchResult.current({ count: 123 }));
+    expect(storeResult.current.count).toBe(123);
+  });
+
+  it('函数形式 dispatch 基于前值更新', () => {
+    const store = createSimpleStore({ count: 5 });
+    const { result } = renderHook(() => useGlobalStoreDispatch(store));
+
+    act(() => result.current((prev) => ({ count: prev.count * 2 })));
+    expect(store.getState().count).toBe(10);
+  });
 });

--- a/src/hooks/use-store.tsx
+++ b/src/hooks/use-store.tsx
@@ -2,12 +2,9 @@
 import {
   createContext,
   useContext,
-  useReducer,
   useCallback,
   useSyncExternalStore,
-  useMemo,
   useRef,
-  useEffect,
   type ReactNode,
   type JSX,
 } from 'react';
@@ -25,17 +22,52 @@ export interface CreateStoreOptions<T> {
   initialState: T;
 }
 
+/**
+ * 构造一个 React 之外的外部 store。state 作为闭包变量持有，
+ * 避免依赖 React render / useEffect 的提交时机，天然规避并发模式 tearing。
+ */
+function makeExternalStore<T extends object>(initial: T): Store<T> {
+  let state = initial;
+  const listeners = new Set<Listener>();
+
+  return {
+    getState: () => state,
+    setState: (partial) => {
+      const resolved =
+        typeof partial === 'function'
+          ? (partial as (prev: T) => Partial<T>)(state)
+          : partial;
+      state = { ...state, ...resolved };
+      listeners.forEach((l) => l());
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
 function createStoreContext<T>() {
   return createContext<Store<T> | null>(null);
 }
 
+/**
+ * 在 React Context 外用外部 store 持有状态。
+ *
+ * 旧实现用 useReducer + useRef + useEffect 通知订阅者 —— 并发模式下
+ * stateRef 在 render 阶段被写入，订阅者通知却在 commit 阶段发生，
+ * 会产生 tearing；现在改为每个 StoreProvider 实例自有一个 makeExternalStore，
+ * 读写都跑在 React 之外，useSyncExternalStore 做一致性保证。
+ */
 export function createStore<T extends object>(
   options: CreateStoreOptions<T>
 ): {
   StoreProvider: (props: { children: ReactNode; initialState?: Partial<T> }) => JSX.Element;
   useStore: () => T;
   useStoreDispatch: () => (partial: Partial<T> | ((prev: T) => Partial<T>)) => void;
-  useStoreSelector: <R>(selector: (state: T) => R) => R;
+  useStoreSelector: <R>(selector: (state: T) => R, equalityFn?: (a: R, b: R) => boolean) => R;
 } {
   const name = options.name || `store_${Math.random().toString(36).slice(2)}`;
   const StoreContext = createStoreContext<T>();
@@ -47,52 +79,25 @@ export function createStore<T extends object>(
     children: ReactNode;
     initialState?: Partial<T>;
   }) {
-    const listenersRef = useRef<Set<Listener>>(new Set());
-    const [localState, dispatch] = useReducer(
-      (s: T, a: Partial<T>) => ({ ...s, ...a }),
-      initialState ? { ...options.initialState, ...initialState } : options.initialState
-    );
-
-    const stateRef = useRef(localState);
-    stateRef.current = localState;
-
-    const storeValue = useMemo<Store<T>>(
-      () => ({
-        getState: () => stateRef.current,
-        setState: (partial: Partial<T> | ((prev: T) => Partial<T>)) => {
-          const resolved = typeof partial === 'function'
-            ? (partial as (prev: T) => Partial<T>)(stateRef.current)
-            : partial;
-          dispatch(resolved);
-        },
-        subscribe: (listener: Listener) => {
-          listenersRef.current.add(listener);
-          return () => listenersRef.current.delete(listener);
-        },
-      }),
-      []
-    );
-
-    useEffect(() => {
-      listenersRef.current.forEach((listener) => listener());
-    }, [localState]);
-
+    // 每个 Provider 实例一份外部 store。initialState 只在首次挂载时生效。
+    const storeRef = useRef<Store<T> | null>(null);
+    if (storeRef.current === null) {
+      const initial = initialState
+        ? { ...options.initialState, ...initialState }
+        : options.initialState;
+      storeRef.current = makeExternalStore<T>(initial);
+    }
     return (
-      <StoreContext.Provider value={storeValue}>{children}</StoreContext.Provider>
+      <StoreContext.Provider value={storeRef.current}>{children}</StoreContext.Provider>
     );
   }
 
-  function useStore() {
+  function useStore(): T {
     const store = useContext(StoreContext);
     if (!store) {
       throw new Error(`useStore must be used within a ${name}Provider`);
     }
-
-    return useSyncExternalStore(
-      store.subscribe,
-      store.getState,
-      store.getState
-    );
+    return useSyncExternalStore(store.subscribe, store.getState, store.getState);
   }
 
   function useStoreDispatch() {
@@ -100,25 +105,37 @@ export function createStore<T extends object>(
     if (!store) {
       throw new Error(`useStoreDispatch must be used within a ${name}Provider`);
     }
-    return useCallback(
-      (partial: Partial<T> | ((prev: T) => Partial<T>)) => {
-        store.setState(partial);
-      },
-      [store]
-    );
+    // store.setState 是稳定引用，直接返回即可
+    return store.setState;
   }
 
-  function useStoreSelector<R>(selector: (state: T) => R): R {
+  function useStoreSelector<R>(
+    selector: (state: T) => R,
+    equalityFn: (a: R, b: R) => boolean = Object.is,
+  ): R {
     const store = useContext(StoreContext);
     if (!store) {
       throw new Error(`useStoreSelector must be used within a ${name}Provider`);
     }
+    // 缓存最近一次的 selected 值，只要 equalityFn 相等就返回同一引用，
+    // 防止 useSyncExternalStore 在 getSnapshot 返回非稳定引用时警告/死循环。
+    const lastRef = useRef<{ state: T; selected: R } | null>(null);
+    const getSelected = useCallback((): R => {
+      const state = store.getState();
+      if (lastRef.current && lastRef.current.state === state) {
+        return lastRef.current.selected;
+      }
+      const next = selector(state);
+      if (lastRef.current && equalityFn(lastRef.current.selected, next)) {
+        // 值相等但 state 引用变了：更新 state 缓存，复用旧 selected
+        lastRef.current = { state, selected: lastRef.current.selected };
+        return lastRef.current.selected;
+      }
+      lastRef.current = { state, selected: next };
+      return next;
+    }, [store, selector, equalityFn]);
 
-    return useSyncExternalStore(
-      store.subscribe,
-      () => selector(store.getState()),
-      () => selector(store.getState())
-    );
+    return useSyncExternalStore(store.subscribe, getSelected, getSelected);
   }
 
   return {
@@ -129,63 +146,96 @@ export function createStore<T extends object>(
   };
 }
 
+/**
+ * 模块级全局单例 store。无需 Provider。
+ */
 export function createSimpleStore<T extends object>(initialState: T) {
-  let state = initialState;
-  const listeners = new Set<Listener>();
+  const store = makeExternalStore(initialState);
 
-  const store: Store<T> = {
-    getState: () => state,
-    setState: (partial: Partial<T> | ((prev: T) => Partial<T>)) => {
-      const resolved = typeof partial === 'function'
-        ? (partial as (prev: T) => Partial<T>)(state)
-        : partial;
-      state = { ...state, ...resolved };
-      listeners.forEach((l) => l());
-    },
-    subscribe: (listener: Listener) => {
-      listeners.add(listener);
-      return () => listeners.delete(listener);
-    },
-  };
+  function useStore(): T;
+  function useStore<R>(selector: (state: T) => R, equalityFn?: (a: R, b: R) => boolean): R;
+  function useStore<R>(
+    selector?: (state: T) => R,
+    equalityFn: (a: R, b: R) => boolean = Object.is,
+  ): T | R {
+    if (!selector) {
+      return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+    }
+    // 闭包缓存，稳定 getSnapshot 引用
+    const lastRef = useRef<{ state: T; selected: R } | null>(null);
+    const getSelected = useCallback((): R => {
+      const state = store.getState();
+      if (lastRef.current && lastRef.current.state === state) {
+        return lastRef.current.selected;
+      }
+      const next = selector(state);
+      if (lastRef.current && equalityFn(lastRef.current.selected, next)) {
+        lastRef.current = { state, selected: lastRef.current.selected };
+        return lastRef.current.selected;
+      }
+      lastRef.current = { state, selected: next };
+      return next;
+    }, [selector, equalityFn]);
+    return useSyncExternalStore(store.subscribe, getSelected, getSelected);
+  }
+
+  function useDispatch() {
+    return store.setState;
+  }
 
   return {
     ...store,
-    useStore: function () {
-      return useSyncExternalStore(
-        store.subscribe,
-        store.getState,
-        store.getState
-      );
-    },
-    useDispatch: function () {
-      return useCallback(
-        (partial: Partial<T> | ((prev: T) => Partial<T>)) => {
-          store.setState(partial);
-        },
-        []
-      );
-    },
+    useStore,
+    useDispatch,
   };
 }
 
+/**
+ * 直接订阅任意外部 store（必须至少有 subscribe + getState）。
+ * 可选 selector 用于切片订阅，只在 selected 值变化时重新渲染。
+ */
 export function useGlobalStore<T extends object>(store: {
   getState: () => T;
   subscribe: (listener: Listener) => () => void;
-}) {
-  return useSyncExternalStore(
-    store.subscribe,
-    store.getState,
-    store.getState
-  );
+}): T;
+export function useGlobalStore<T extends object, R>(
+  store: {
+    getState: () => T;
+    subscribe: (listener: Listener) => () => void;
+  },
+  selector: (state: T) => R,
+  equalityFn?: (a: R, b: R) => boolean,
+): R;
+export function useGlobalStore<T extends object, R>(
+  store: {
+    getState: () => T;
+    subscribe: (listener: Listener) => () => void;
+  },
+  selector?: (state: T) => R,
+  equalityFn: (a: R, b: R) => boolean = Object.is,
+): T | R {
+  if (!selector) {
+    return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+  }
+  const lastRef = useRef<{ state: T; selected: R } | null>(null);
+  const getSelected = useCallback((): R => {
+    const state = store.getState();
+    if (lastRef.current && lastRef.current.state === state) {
+      return lastRef.current.selected;
+    }
+    const next = selector(state);
+    if (lastRef.current && equalityFn(lastRef.current.selected, next)) {
+      lastRef.current = { state, selected: lastRef.current.selected };
+      return lastRef.current.selected;
+    }
+    lastRef.current = { state, selected: next };
+    return next;
+  }, [store, selector, equalityFn]);
+  return useSyncExternalStore(store.subscribe, getSelected, getSelected);
 }
 
 export function useGlobalStoreDispatch<T extends object>(
   store: { setState: (partial: Partial<T> | ((prev: T) => Partial<T>)) => void }
 ) {
-  return useCallback(
-    (partial: Partial<T> | ((prev: T) => Partial<T>)) => {
-      store.setState(partial);
-    },
-    [store]
-  );
+  return store.setState;
 }

--- a/src/hooks/use-store.tsx
+++ b/src/hooks/use-store.tsx
@@ -158,13 +158,15 @@ export function createSimpleStore<T extends object>(initialState: T) {
     selector?: (state: T) => R,
     equalityFn: (a: R, b: R) => boolean = Object.is,
   ): T | R {
-    if (!selector) {
-      return useSyncExternalStore(store.subscribe, store.getState, store.getState);
-    }
     // 闭包缓存，稳定 getSnapshot 引用
+    // 必须在所有分支前调用 hooks，满足 Rules of Hooks
     const lastRef = useRef<{ state: T; selected: R } | null>(null);
     const getSelected = useCallback((): R => {
       const state = store.getState();
+      if (!selector) {
+        // selector 未传时，返回完整 state（需类型断言为 R）
+        return state as unknown as R;
+      }
       if (lastRef.current && lastRef.current.state === state) {
         return lastRef.current.selected;
       }
@@ -176,6 +178,10 @@ export function createSimpleStore<T extends object>(initialState: T) {
       lastRef.current = { state, selected: next };
       return next;
     }, [selector, equalityFn]);
+
+    if (!selector) {
+      return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+    }
     return useSyncExternalStore(store.subscribe, getSelected, getSelected);
   }
 
@@ -214,12 +220,14 @@ export function useGlobalStore<T extends object, R>(
   selector?: (state: T) => R,
   equalityFn: (a: R, b: R) => boolean = Object.is,
 ): T | R {
-  if (!selector) {
-    return useSyncExternalStore(store.subscribe, store.getState, store.getState);
-  }
+  // 必须在所有分支前调用 hooks，满足 Rules of Hooks
   const lastRef = useRef<{ state: T; selected: R } | null>(null);
   const getSelected = useCallback((): R => {
     const state = store.getState();
+    if (!selector) {
+      // selector 未传时，返回完整 state（需类型断言为 R）
+      return state as unknown as R;
+    }
     if (lastRef.current && lastRef.current.state === state) {
       return lastRef.current.selected;
     }
@@ -231,6 +239,10 @@ export function useGlobalStore<T extends object, R>(
     lastRef.current = { state, selected: next };
     return next;
   }, [store, selector, equalityFn]);
+
+  if (!selector) {
+    return useSyncExternalStore(store.subscribe, store.getState, store.getState);
+  }
   return useSyncExternalStore(store.subscribe, getSelected, getSelected);
 }
 

--- a/src/hooks/use-store.tsx
+++ b/src/hooks/use-store.tsx
@@ -119,19 +119,19 @@ export function createStore<T extends object>(
     }
     // 缓存最近一次的 selected 值，只要 equalityFn 相等就返回同一引用，
     // 防止 useSyncExternalStore 在 getSnapshot 返回非稳定引用时警告/死循环。
-    const lastRef = useRef<{ state: T; selected: R } | null>(null);
+    const lastRef = useRef<{ state: T; selected: R; selector: (state: T) => R } | null>(null);
     const getSelected = useCallback((): R => {
       const state = store.getState();
-      if (lastRef.current && lastRef.current.state === state) {
+      if (lastRef.current && lastRef.current.state === state && lastRef.current.selector === selector) {
         return lastRef.current.selected;
       }
       const next = selector(state);
       if (lastRef.current && equalityFn(lastRef.current.selected, next)) {
         // 值相等但 state 引用变了：更新 state 缓存，复用旧 selected
-        lastRef.current = { state, selected: lastRef.current.selected };
+        lastRef.current = { state, selected: lastRef.current.selected, selector };
         return lastRef.current.selected;
       }
-      lastRef.current = { state, selected: next };
+      lastRef.current = { state, selected: next, selector };
       return next;
     }, [store, selector, equalityFn]);
 
@@ -160,22 +160,22 @@ export function createSimpleStore<T extends object>(initialState: T) {
   ): T | R {
     // 闭包缓存，稳定 getSnapshot 引用
     // 必须在所有分支前调用 hooks，满足 Rules of Hooks
-    const lastRef = useRef<{ state: T; selected: R } | null>(null);
+    const lastRef = useRef<{ state: T; selected: R; selector: (state: T) => R } | null>(null);
     const getSelected = useCallback((): R => {
       const state = store.getState();
       if (!selector) {
         // selector 未传时，返回完整 state（需类型断言为 R）
         return state as unknown as R;
       }
-      if (lastRef.current && lastRef.current.state === state) {
+      if (lastRef.current && lastRef.current.state === state && lastRef.current.selector === selector) {
         return lastRef.current.selected;
       }
       const next = selector(state);
       if (lastRef.current && equalityFn(lastRef.current.selected, next)) {
-        lastRef.current = { state, selected: lastRef.current.selected };
+        lastRef.current = { state, selected: lastRef.current.selected, selector };
         return lastRef.current.selected;
       }
-      lastRef.current = { state, selected: next };
+      lastRef.current = { state, selected: next, selector };
       return next;
     }, [selector, equalityFn]);
 
@@ -221,22 +221,22 @@ export function useGlobalStore<T extends object, R>(
   equalityFn: (a: R, b: R) => boolean = Object.is,
 ): T | R {
   // 必须在所有分支前调用 hooks，满足 Rules of Hooks
-  const lastRef = useRef<{ state: T; selected: R } | null>(null);
+  const lastRef = useRef<{ state: T; selected: R; selector: (state: T) => R } | null>(null);
   const getSelected = useCallback((): R => {
     const state = store.getState();
     if (!selector) {
       // selector 未传时，返回完整 state（需类型断言为 R）
       return state as unknown as R;
     }
-    if (lastRef.current && lastRef.current.state === state) {
+    if (lastRef.current && lastRef.current.state === state && lastRef.current.selector === selector) {
       return lastRef.current.selected;
     }
     const next = selector(state);
     if (lastRef.current && equalityFn(lastRef.current.selected, next)) {
-      lastRef.current = { state, selected: lastRef.current.selected };
+      lastRef.current = { state, selected: lastRef.current.selected, selector };
       return lastRef.current.selected;
     }
-    lastRef.current = { state, selected: next };
+    lastRef.current = { state, selected: next, selector };
     return next;
   }, [store, selector, equalityFn]);
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,16 @@
 "use client";
 
+import {
+  BrowserRouter,
+  HashRouter,
+  type BrowserRouterProps,
+  type HashRouterProps,
+} from 'react-router';
+import { createElement, type ReactElement } from 'react';
+
 export {
   BrowserRouter as ChenRouter,
+  HashRouter as ChenHashRouter,
   Route,
   Routes,
   Link,
@@ -14,3 +23,34 @@ export {
   useLocation,
   useMatch,
 } from 'react-router';
+
+export type ChenRouterMode = 'browser' | 'hash' | 'auto';
+
+export interface ChenAdaptiveRouterProps extends BrowserRouterProps, HashRouterProps {
+  /**
+   * 'browser' —— HTML5 History API（默认，SPA/SSR）
+   * 'hash'    —— location.hash（Electron file:// 下必须用这个，否则刷新/深链 404）
+   * 'auto'    —— 运行时探测：file: 协议用 hash，其它用 browser
+   */
+  mode?: ChenRouterMode;
+}
+
+/**
+ * 自适应 Router：根据 mode 或运行时环境选择 BrowserRouter / HashRouter。
+ *
+ * Electron 打包渲染进程通过 file:// 加载 index.html，BrowserRouter 在这种协议下
+ * 刷新任何非根路径都会 404（没有服务端 SPA fallback）。使用 mode="hash" 或
+ * mode="auto" 可以避免这个问题。
+ */
+export function ChenAdaptiveRouter(props: ChenAdaptiveRouterProps): ReactElement {
+  const { mode = 'auto', ...rest } = props;
+  const resolved =
+    mode === 'browser'
+      ? 'browser'
+      : mode === 'hash'
+        ? 'hash'
+        : typeof window !== 'undefined' && window.location.protocol === 'file:'
+          ? 'hash'
+          : 'browser';
+  return createElement(resolved === 'hash' ? HashRouter : BrowserRouter, rest);
+}

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { renderToString as reactRenderToString } from 'react-dom/server';
 import { renderToPipeableStream } from 'react-dom/server';
-import type { Writable } from 'stream';
+import { PassThrough, type Writable } from 'stream';
 
 export { StaticRouter as ChenSSRRouter } from 'react-router';
 
@@ -78,24 +78,42 @@ export function renderToStream(
 ): void {
   const shell = createHTMLShell(options);
 
-  const { pipe } = renderToPipeableStream(element, {
+  // React 的 PipeableStream.pipe(dest) 没有 { end: false } 选项，pipe 完成后
+  // 会自动 writable.end()。若直接 pipe(writable)，onAllReady 里再 write+end
+  // 会抛 ERR_STREAM_WRITE_AFTER_END，afterContent（</div></body></html>）丢失。
+  //
+  // 方案：插一层 PassThrough —— React 流入 PassThrough，PassThrough 'end'
+  // 触发时再把 afterContent 写进用户的 writable 并结束。
+  const bridge = new PassThrough();
+  // 用 pipe({ end: false }) 保留 writable 的 backpressure 语义；end 由我们手动触发
+  bridge.pipe(writable, { end: false });
+  bridge.on('end', () => {
+    writable.write(shell.afterContent);
+    writable.end();
+    options.onAllReady?.();
+  });
+  bridge.on('error', (err: Error) => {
+    options.onError?.(err);
+    writable.destroy(err);
+  });
+
+  const { pipe, abort } = renderToPipeableStream(element, {
     onShellReady() {
       writable.write(shell.beforeContent);
-      pipe(writable);
+      pipe(bridge);
       options.onShellReady?.();
     },
     onShellError(error) {
+      // Shell 渲染失败，尚未写过任何东西，交给调用方决定（通常返回 500）
       options.onShellError?.(error);
-    },
-    onAllReady() {
-      writable.write(shell.afterContent);
-      writable.end();
-      options.onAllReady?.();
     },
     onError(error) {
       options.onError?.(error);
     },
   });
+
+  // 暴露 abort 供调用方（如超时时）调用
+  (writable as Writable & { __chenAbort?: () => void }).__chenAbort = abort;
 }
 
 // ─── renderToString ─────────────────────────────────────────────────────────

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -88,13 +88,29 @@ export function renderToStream(
   // 用 pipe({ end: false }) 保留 writable 的 backpressure 语义；end 由我们手动触发
   bridge.pipe(writable, { end: false });
   bridge.on('end', () => {
-    writable.write(shell.afterContent);
-    writable.end();
-    options.onAllReady?.();
+    // 检查 writable 是否已被销毁或结束
+    if (writable.destroyed || writable.writableEnded) {
+      return;
+    }
+    try {
+      writable.write(shell.afterContent);
+      writable.end();
+      options.onAllReady?.();
+    } catch (err) {
+      options.onError?.(err);
+      writable.destroy(err instanceof Error ? err : new Error(String(err)));
+    }
   });
   bridge.on('error', (err: Error) => {
     options.onError?.(err);
     writable.destroy(err);
+  });
+  // 双向错误传播：writable 独立错误需要清理 bridge
+  writable.on('error', (err: Error) => {
+    options.onError?.(err);
+    if (bridge.destroy) {
+      bridge.destroy(err);
+    }
   });
 
   const { pipe, abort } = renderToPipeableStream(element, {


### PR DESCRIPTION
## Summary

修复 Logos Workstation 集成时发现的 3 个阻塞问题：

### P0

- **SSR `renderToStream` 双重 `end()`** — `pipe(writable)` 默认在 React 流结束时调用 `writable.end()`，随后 `onAllReady` 里再 `write(afterContent) + end()` 会抛 `ERR_STREAM_WRITE_AFTER_END`，`</div></body></html>` 永远写不出去。插 `PassThrough` 桥接，`bridge.pipe(writable, { end: false })` 保留 backpressure，bridge `'end'` 再手动写 afterContent。
- **Electron 下只有 `BrowserRouter`** — 打包渲染进程通过 `file://` 加载 `index.html`，`BrowserRouter` 刷新/深链 404（无 SPA fallback）。新增 `ChenHashRouter` 与 `ChenAdaptiveRouter`（`mode: 'browser' | 'hash' | 'auto'`，`auto` 在 `file:` 协议下自动走 hash）。

### P1

- **`createStore` tearing** — 旧实现 `useReducer` + `stateRef` (render 阶段写) + `useEffect` 通知订阅者，并发模式 / StrictMode 下 state 写入与通知时机错位可能产生 tearing。改为每个 `StoreProvider` 实例挂一份 `makeExternalStore`，state 完全脱离 React render/commit 周期。
- **getSnapshot 不稳定** — `useStoreSelector` / `createSimpleStore.useStore(selector)` / `useGlobalStore(store, selector)` 三个路径之前每次调用 `selector` 都返回新引用，触发 React 18 的 "The result of getSnapshot should be cached" 警告、并可能在某些 selector 下死循环。用 `lastRef` 缓存 `{state, selected}` + `equalityFn` 参数（默认 `Object.is`），相等时返回上次的引用。
- **selector 重载** — `useGlobalStore` 与 `createSimpleStore.useStore` 新增可选 `selector` / `equalityFn`，允许切片订阅。Logos `workspaceStore` 在 Monaco 打字时能显著减少重渲染。

## Test plan

- [x] `npx tsc --noEmit` 干净
- [x] `npx vitest run` 62/62 通过（覆盖 createStore / createSimpleStore / useGlobalStore 既有用例）
- [x] `npm run build` 成功产出 `dist/`
- [ ] Logos workstation 侧 `ChenAdaptiveRouter` 打包测试（在 Logos PR 中验）
- [ ] 手动验证 SSR `renderToStream` 末尾 `</body></html>` 真的被写出（后续集成测试）

## Follow-ups (P2, 下一轮 PR)

- SSR：`StaticHandlerContext.status` / `<Navigate>` 映射 HTTP 状态码
- SSR：`loader` / `action` / data router 支持
- 文件路由：`handleHotUpdate` 别对所有 `pages/**` 改动 full-reload，尽量保留路由边界的 HMR
- 文件路由：Windows 反斜杠路径 `startsWith(pagesDir)` 规范化
- CLI：`--install` 自动装依赖
- persist middleware（Logos 现状是每个 store 手写 localStorage）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adaptive router with auto-detection to choose browser or hash routing.

* **Improvements**
  * Store hooks support selector-based subscriptions with optional equality for stable updates.
  * Simplified dispatch usage in store hooks.
  * Render streams now use a bridged stream and expose an explicit abort mechanism for safer completion and error forwarding.
  * Server-side rendering: more robust stream/error handling and controlled shell emission.

* **Tests**
  * New test suites covering router selection, SSR streaming behavior, and store selector/equality semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->